### PR TITLE
Fix a segfault

### DIFF
--- a/loc_history.c
+++ b/loc_history.c
@@ -81,6 +81,10 @@ void init_loc_history(yed_event *event) {
         tmp_path = strtok(line, s);
         tmp_row = strtok(NULL, s);
         tmp_col = strtok(NULL, s);
+	    
+	if (tmp_path == NULL || tmp_row == NULL || tmp_col == NULL){
+	    continue;
+	}
 
         loc_data_t tmp;
         tmp.row = atoi(tmp_row);
@@ -187,6 +191,10 @@ void write_back_loc_history(yed_event *event) {
         tmp_path = strtok(line, s);
         tmp_row = strtok(NULL, s);
         tmp_col = strtok(NULL, s);
+	    
+	if (tmp_path == NULL || tmp_row == NULL || tmp_col == NULL){
+	    continue;
+	}
 
         loc_data_t tmp;
         tmp.row = atoi(tmp_row);


### PR DESCRIPTION
I don't know how I got it, but I ended up with the line
 57 1
in my location history file. when you did the strtok it did not find enough tokens and one of them ended up returning NULL which atoi dereferenced segfaulting the program. This fix may not fix the actual problem of how that actually ended up in the file, but the program does not segfault  anymore.